### PR TITLE
Fix light client reader and add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in the repo. Unless a
+# later match takes precedence, they will be requested for review when someone
+# opens a pull request.
+
+*       @nomaxg @ImJeremyHe @sveitser

--- a/client/client.go
+++ b/client/client.go
@@ -92,12 +92,18 @@ func (c *Client) FetchTransactionsInBlock(ctx context.Context, blockHeight uint6
 	}
 
 	if res.Proof == nil {
-		return TransactionsInBlock{Transactions: txs, Proof: nil}, nil
+		return TransactionsInBlock{}, nil
+	}
+
+	vidCommon, err := c.FetchVidCommonByHeight(ctx, blockHeight)
+	if err != nil {
+		return TransactionsInBlock{}, err
 	}
 
 	return TransactionsInBlock{
 		Transactions: txs,
 		Proof:        *res.Proof,
+		VidCommon:    vidCommon,
 	}, nil
 
 }

--- a/client/client.go
+++ b/client/client.go
@@ -28,11 +28,11 @@ func NewClient(url string) *Client {
 }
 
 func (c *Client) FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error) {
-	var res types.VidCommon
+	var res types.VidCommonQueryData
 	if err := c.get(ctx, &res, "availability/vid/common/%d", blockHeight); err != nil {
 		return types.VidCommon{}, err
 	}
-	return res, nil
+	return res.Common, nil
 }
 
 func (c *Client) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {

--- a/client/client.go
+++ b/client/client.go
@@ -65,9 +65,7 @@ func (c *Client) FetchTransactionsInBlock(ctx context.Context, blockHeight uint6
 	if err := c.get(ctx, &res, "availability/block/%d/namespace/%d", blockHeight, namespace); err != nil {
 		return TransactionsInBlock{}, err
 	}
-	if res.Proof == nil {
-		return TransactionsInBlock{}, fmt.Errorf("field proof of type NamespaceResponse is required")
-	}
+
 	if res.Transactions == nil {
 		return TransactionsInBlock{}, fmt.Errorf("field transactions of type NamespaceResponse is required")
 	}
@@ -79,6 +77,14 @@ func (c *Client) FetchTransactionsInBlock(ctx context.Context, blockHeight uint6
 			return TransactionsInBlock{}, fmt.Errorf("transaction %d has wrong namespace (%d, expected %d)", i, tx.Namespace, namespace)
 		}
 		txs = append(txs, tx.Payload)
+	}
+
+	if len(txs) > 0 && res.Proof == nil {
+		return TransactionsInBlock{}, fmt.Errorf("field proof of type NamespaceResponse is required")
+	}
+
+	if res.Proof == nil {
+		return TransactionsInBlock{Transactions: txs, Proof: nil}, nil
 	}
 
 	return TransactionsInBlock{

--- a/client/client.go
+++ b/client/client.go
@@ -27,6 +27,14 @@ func NewClient(url string) *Client {
 	}
 }
 
+func (c *Client) FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error) {
+	var res types.VidCommon
+	if err := c.get(ctx, &res, "availability/vid/common/%d", blockHeight); err != nil {
+		return types.VidCommon{}, err
+	}
+	return res, nil
+}
+
 func (c *Client) FetchLatestBlockHeight(ctx context.Context) (uint64, error) {
 	var res uint64
 	if err := c.get(ctx, &res, "status/block-height"); err != nil {

--- a/client/query.go
+++ b/client/query.go
@@ -26,7 +26,8 @@ type TransactionsInBlock struct {
 	// The transactions.
 	Transactions []types.Bytes `json:"transactions"`
 	// A proof that these are all the transactions in the block with the requested namespace.
-	Proof types.NamespaceProof `json:"proof"`
+	Proof     types.NamespaceProof `json:"proof"`
+	VidCommon types.VidCommon      `json:"vidCommon"`
 }
 
 func (t *TransactionsInBlock) UnmarshalJSON(b []byte) error {

--- a/types/types.go
+++ b/types/types.go
@@ -13,6 +13,8 @@ import (
 
 type TaggedBase64 = tagged_base64.TaggedBase64
 
+type VidCommon = json.RawMessage
+
 type Header struct {
 	ChainConfig         *ResolvableChainConfig `json:"chain_config"`
 	Height              uint64                 `json:"height"`

--- a/types/types.go
+++ b/types/types.go
@@ -15,6 +15,13 @@ type TaggedBase64 = tagged_base64.TaggedBase64
 
 type VidCommon = json.RawMessage
 
+type VidCommonQueryData struct {
+	Height      uint64        `json:"height"`
+	BlockHash   *TaggedBase64 `json:"block_hash"`
+	PayloadHash *TaggedBase64 `json:"payload_hash"`
+	Common      VidCommon     `json:"common"`
+}
+
 type Header struct {
 	ChainConfig         *ResolvableChainConfig `json:"chain_config"`
 	Height              uint64                 `json:"height"`


### PR DESCRIPTION
Close #43 
### This PR:
- Fix the `LightClientReader` and make sure that the `LightClientReader` always implements the `LightClientInterface`
- Implements the `IsHotShotLive` method
- Add CODEOWNERS

### Key point to review
- `IsHotShotLive`