### PR TITLE
Remove unused field from `HotShotBlockMerkleProof`

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -279,7 +279,6 @@ type BlockMerkleSnapshot struct {
 type BlockMerkleRoot = Commitment
 
 type HotShotBlockMerkleProof struct {
-	Pos   string          `json:"pos"`
 	Proof json.RawMessage `json:"proof"`
 }
 


### PR DESCRIPTION
Closes #none

### This PR:
Modifies the `HotShotBlockMerkleProof` struct to remove the `Pos` field as it was unused. 

### This PR does not:

Cause any downstream impact in `nitro-espresso-integration` codebase.

### Key places to review:

types/types.go `HotShotBlockMerkleProof` struct

### How to test this PR:  -->

`just test`
