### PR TITLE
Use u256 instead of hash in signature

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -96,7 +96,7 @@ func waitForWith(
 }
 
 func waitForEspressoNode(t *testing.T, ctx context.Context) error {
-	return waitForWith(t, ctx, 30*time.Second, 1*time.Second, func() bool {
+	err := waitForWith(t, ctx, 30*time.Second, 1*time.Second, func() bool {
 		out, err := exec.Command("curl", "-s", "-L", "-f", "http://localhost:21000/availability/block/10").Output()
 		if err != nil {
 			log.Warn("error executing curl command:", "err", err)
@@ -105,4 +105,10 @@ func waitForEspressoNode(t *testing.T, ctx context.Context) error {
 
 		return len(out) > 0
 	})
+	if err != nil {
+		return err
+	}
+	// Wait a bit for dev node to be ready totally
+	time.Sleep(5 * time.Second)
+	return nil
 }

--- a/types/common/types.go
+++ b/types/common/types.go
@@ -269,9 +269,9 @@ func (self *FeeInfo) Commit() Commitment {
 }
 
 type Signature struct {
-	R common.Hash `json:"r"`
-	S common.Hash `json:"s"`
-	V uint64      `json:"v"`
+	R U256   `json:"r"`
+	S U256   `json:"s"`
+	V uint64 `json:"v"`
 }
 
 func (s *Signature) Bytes() [65]byte {

--- a/types/header.go
+++ b/types/header.go
@@ -4,13 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
-	tagged_base64 "github.com/EspressoSystems/espresso-sequencer-go/tagged-base64"
 	common_types "github.com/EspressoSystems/espresso-sequencer-go/types/common"
-	"github.com/EspressoSystems/espresso-sequencer-go/types/v0/v0_1"
 	v01 "github.com/EspressoSystems/espresso-sequencer-go/types/v0/v0_1"
 	v02 "github.com/EspressoSystems/espresso-sequencer-go/types/v0/v0_2"
 	v03 "github.com/EspressoSystems/espresso-sequencer-go/types/v0/v0_3"
-	common "github.com/ethereum/go-ethereum/common"
 )
 
 // Republic
@@ -154,49 +151,4 @@ func parseHeader(data []byte) (HeaderInterface, error) {
 	}
 
 	return nil, fmt.Errorf("version error: %v", version)
-}
-
-// For some intricate reasons, rollups need to build a dummy header as a placeholder. However, an empty Header can be serialized
-// but can not be deserialized because of the checks. Thus we provide this dummy header as a workaround.
-func GetDummyHeader() v0_1.Header {
-	var payloadCommitment, _ = tagged_base64.Parse("HASH~1yS-KEtL3oDZDBJdsW51Pd7zywIiHesBZsTbpOzrxOfu")
-	var builderCommitment, _ = tagged_base64.Parse("BUILDER_COMMITMENT~1yS-KEtL3oDZDBJdsW51Pd7zywIiHesBZsTbpOzrxOdZ")
-	var blockMerkleTreeRoot, _ = tagged_base64.Parse("MERKLE_COMM~yB4_Aqa35_PoskgTpcCR1oVLh6BUdLHIs7erHKWi-usUAAAAAAAAAAEAAAAAAAAAJg")
-	var feeMerkleTreeRoot, _ = tagged_base64.Parse("MERKLE_COMM~VJ9z239aP9GZDrHp3VxwPd_0l28Hc5KEAB1pFeCIxhYgAAAAAAAAAAIAAAAAAAAAdA")
-	var blockInfo = common_types.L1BlockInfo{
-		Number:    123,
-		Timestamp: *common_types.NewU256().SetUint64(0x456),
-		Hash:      common.Hash{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef},
-	}
-
-	return v0_1.Header{
-		ChainConfig: &v0_1.ResolvableChainConfig{
-			ChainConfig: v0_1.EitherChainConfig{
-				Left: &v0_1.ChainConfig{
-					ChainId:      *common_types.NewU256().SetUint64(0x8a19).ToDecimal(),
-					MaxBlockSize: *common_types.NewU256().SetUint64(10240).ToDecimal(),
-					BaseFee:      *common_types.NewU256().SetUint64(0).ToDecimal(),
-					FeeContract:  &common.Address{},
-					FeeRecipient: common.Address{},
-				},
-			},
-		},
-		Height:    0,
-		Timestamp: 789,
-		L1Head:    124,
-		NsTable: &common_types.NsTable{
-			Bytes: []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-		},
-		BlockMerkleTreeRoot: blockMerkleTreeRoot,
-		FeeMerkleTreeRoot:   feeMerkleTreeRoot,
-		BuilderCommitment:   builderCommitment,
-		PayloadCommitment:   payloadCommitment,
-		FeeInfo:             &common_types.FeeInfo{Account: common.HexToAddress("0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"), Amount: *common_types.NewU256().SetUint64(0).ToDecimal()},
-		L1Finalized:         &blockInfo,
-		BuilderSignature: &common_types.Signature{
-			R: common.HexToHash("0x1f92bab6350d4f33e04f9e9278d89f644d0abea16d6f882e91f87bec4e0ba53d"),
-			S: common.HexToHash("0x2067627270a89b06e7486c2c56fef0fee5f49a14b296a1cde580b0b40fa7430f"),
-			V: uint64(27),
-		},
-	}
 }

--- a/types/header_test.go
+++ b/types/header_test.go
@@ -123,3 +123,36 @@ func getHeaderFromTestFile(path string, t *testing.T) HeaderInterface {
 
 	return headerImpl.Header
 }
+
+func TestUnmarshalSignature(t *testing.T) {
+	// `r` ans `s` are hex string of odd length.
+	// It should be unmarshalled successfully
+	data := `
+{
+    "r": "0xa1c",
+    "s": "0x202",
+    "v": 27
+}
+	`
+	var signature Signature
+	err := json.Unmarshal([]byte(data), &signature)
+	if err != nil {
+		t.Fatal("Error unmarshaling:", err)
+	}
+	expectedR := int64(2588)
+	expectedS := int64(514)
+	expectedV := uint64(27)
+
+	if expectedR != signature.R.Int64() {
+		t.Fatal("getting a wrong r in unmarshal signature")
+	}
+
+	if expectedS != signature.S.Int64() {
+		t.Fatal("getting a wrong r in unmarshal signature")
+	}
+
+	if expectedV != signature.V {
+		t.Fatal("getting a wrong r in unmarshal signature")
+	}
+
+}


### PR DESCRIPTION
Close https://github.com/EspressoSystems/espresso-sequencer/issues/2281

### This PR:
- Use the u256 type instead of hash in signature.
- Remove the `GetDummyHeader` function since it is returnning a dummy header of oudated version v0.1. Should have no one using it.

### This PR does not:
Change any logic