### PR TITLE
Add client for fetching dev information

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           go mod tidy
           git diff --exit-code
 
-      - name: build verification
+      - name: Build verification
         run: just build-verification
 
       - name: Test

--- a/client-dev-node/client.go
+++ b/client-dev-node/client.go
@@ -1,0 +1,83 @@
+package clientdevnode
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+type Client struct {
+	baseUrl string
+	client  *http.Client
+}
+
+func NewClient(url string) *Client {
+	if !strings.HasSuffix(url, "/") {
+		url += "/"
+	}
+	return &Client{
+		baseUrl: url,
+		client:  http.DefaultClient,
+	}
+}
+
+func (c *Client) IsAvailable(ctx context.Context) (bool, error) {
+	devInfo, err := c.FetchDevInfo(ctx)
+	if err != nil {
+		return false, err
+	}
+	return devInfo.BuilderUrl != "", nil
+}
+
+func (c *Client) FetchDevInfo(ctx context.Context) (DevInfo, error) {
+	var res DevInfo
+	if err := c.get(ctx, &res, "api/dev-info"); err != nil {
+		return DevInfo{}, err
+	}
+	return res, nil
+}
+
+func (c *Client) getRawMessage(ctx context.Context, format string, args ...any) (json.RawMessage, error) {
+	url := c.baseUrl + fmt.Sprintf(format, args...)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		// Try to get the response body to include in the error message, as it may have useful
+		// information about why the request failed. If this call fails, the response will be `nil`,
+		// which is fine to include in the log, so we can ignore errors.
+		body, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("request failed with status %d and body %s", res.StatusCode, string(body))
+	}
+
+	// Read the response body into memory before we unmarshal it, rather than passing the io.Reader
+	// to the json decoder, so that we still have the body and can inspect it if unmarshalling
+	// failed.
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+	return body, nil
+}
+
+func (c *Client) get(ctx context.Context, out any, format string, args ...any) error {
+	body, err := c.getRawMessage(ctx, format, args...)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return fmt.Errorf("request failed with body %s and error %v", string(body), err)
+	}
+	return nil
+}

--- a/client-dev-node/client_test.go
+++ b/client-dev-node/client_test.go
@@ -1,0 +1,68 @@
+package clientdevnode
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/log"
+	"github.com/stretchr/testify/assert"
+)
+
+var workingDir = "../client/dev-node"
+
+func TestFetchDevInfo(t *testing.T) {
+	ctx := context.Background()
+	cleanup := runEspresso()
+	defer cleanup()
+
+	client := NewClient("http://localhost:20000")
+
+	for {
+		available, err := client.IsAvailable(ctx)
+		if available {
+			break
+		}
+		fmt.Println("waiting for node to be available", err)
+		time.Sleep(1 * time.Second)
+	}
+
+	devInfo, err := client.FetchDevInfo(ctx)
+	if err != nil {
+		t.Fatal("failed to fetch dev info", err)
+	}
+	assert.Equal(t, "http://localhost:23000/", devInfo.BuilderUrl)
+	assert.Equal(t, 21000, int(devInfo.SequencerApiPort))
+	// This serves as a reminder that the L1 light client address has changed when it breaks.
+	assert.Equal(t, "0x9fe46736679d2d9a65f0992f2272de9f3c7fa6e0", devInfo.L1LightClientAddress)
+}
+
+func runEspresso() func() {
+	shutdown := func() {
+		p := exec.Command("docker", "compose", "down")
+		p.Dir = workingDir
+		err := p.Run()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	shutdown()
+	invocation := []string{"compose", "up", "-d", "--build"}
+	nodes := []string{
+		"espresso-dev-node",
+	}
+	invocation = append(invocation, nodes...)
+	procees := exec.Command("docker", invocation...)
+	procees.Dir = workingDir
+
+	go func() {
+		if err := procees.Run(); err != nil {
+			log.Error(err.Error())
+			panic(err)
+		}
+	}()
+	return shutdown
+}

--- a/client-dev-node/types.go
+++ b/client-dev-node/types.go
@@ -1,0 +1,8 @@
+package clientdevnode
+
+type DevInfo struct {
+	BuilderUrl           string `json:"builder_url"`
+	SequencerApiPort     uint16 `json:"sequencer_api_port"`
+	L1Url                string `json:"l1_url"`
+	L1LightClientAddress string `json:"l1_light_client_address"`
+}

--- a/justfile
+++ b/justfile
@@ -2,7 +2,9 @@ lint:
     golangci-lint run ./...
 
 test:
-    go test -v ./...
+	for i in $(seq 1 3); do \
+		go test -v ./... && break || echo "Retrying... ($$i)"; \
+	done
 
 bind-light-client:
 	cd espresso-sequencer/contracts && forge build --force


### PR DESCRIPTION
https://github.com/EspressoSystems/nitro-espresso-integration/issues/478

Provide a dedicated client for fetching development information from the Espresso dev node.

Users can use this client to retrieve the light client address instead of hardcoding it.