### PR TITLE
Add full api interface

### DIFF
--- a/.github/workflows/build-static.yml
+++ b/.github/workflows/build-static.yml
@@ -39,6 +39,7 @@ jobs:
         # https://github.com/briansmith/ring/blob/main/mk/install-build-tools.sh
         if: ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         run: |
+          sudo apt update
           sudo apt-get install qemu-user gcc-aarch64-linux-gnu libc6-dev-arm64-cross
           echo CFLAGS_aarch64_unknown_linux_gnu="--sysroot=/usr/aarch64-linux-gnu" >> ${{ github.env }}
           echo CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc >> ${{ github.env }}

--- a/client/client.go
+++ b/client/client.go
@@ -15,6 +15,7 @@ import (
 
 var _ QueryService = (*Client)(nil)
 var _ SubmitAPI = (*Client)(nil)
+var _ EspressoClient = (*Client)(nil)
 
 type Client struct {
 	baseUrl string

--- a/client/clientApi.go
+++ b/client/clientApi.go
@@ -1,15 +1,10 @@
 package client
 
-import(
-	"context"
-	"encoding/json"
-
-	types "github.com/EspressoSystems/espresso-sequencer-go/types"
-	
-	common "github.com/EspressoSystems/espresso-sequencer-go/types/common"
-)
+// This interface represents the full API of clients defined in this package
+// It is provided for consumers that wish to use the full scope of the EspressoClient
+// while still providing the ability to use mock structures for testing.
 
 type EspressoClient interface{ 
-    QueryService,
-    SubmitAPI,
+    QueryService;
+    SubmitAPI;
 }

--- a/client/clientApi.go
+++ b/client/clientApi.go
@@ -1,0 +1,29 @@
+package client
+
+import(
+	"context"
+	"encoding/json"
+
+	types "github.com/EspressoSystems/espresso-sequencer-go/types"
+	common "github.com/EspressoSystems/espresso-sequencer-go/types/common"
+)
+
+type EspressoClient interface{ 
+  // Get the latest block number
+	FetchLatestBlockHeight(ctx context.Context) (uint64, error)
+	// Get the header for block number `height`.
+	FetchHeaderByHeight(ctx context.Context, height uint64) (types.HeaderImpl, error)
+	// Get the raw header for block number `height`.
+	FetchRawHeaderByHeight(ctx context.Context, height uint64) (json.RawMessage, error)
+	// Get the headers starting from the given :from up until the given :until
+	FetchHeadersByRange(ctx context.Context, from uint64, until uint64) ([]types.HeaderImpl, error)
+	// Get the transactions belonging to the given namespace at the block height,
+	// along with a proof that these are all such transactions.
+	FetchTransactionsInBlock(ctx context.Context, blockHeight uint64, namespace uint64) (TransactionsInBlock, error)
+	// Get the transaction by its hash.
+	FetchTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.TransactionQueryData, error)
+	// Get the VidCommon for the given block height.
+	FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error)
+	// Submit a transaction to the espresso sequencer.
+	SubmitTransaction(ctx context.Context, tx common.Transaction) (*common.TaggedBase64, error)
+}

--- a/client/clientApi.go
+++ b/client/clientApi.go
@@ -5,25 +5,11 @@ import(
 	"encoding/json"
 
 	types "github.com/EspressoSystems/espresso-sequencer-go/types"
+	
 	common "github.com/EspressoSystems/espresso-sequencer-go/types/common"
 )
 
 type EspressoClient interface{ 
-  // Get the latest block number
-	FetchLatestBlockHeight(ctx context.Context) (uint64, error)
-	// Get the header for block number `height`.
-	FetchHeaderByHeight(ctx context.Context, height uint64) (types.HeaderImpl, error)
-	// Get the raw header for block number `height`.
-	FetchRawHeaderByHeight(ctx context.Context, height uint64) (json.RawMessage, error)
-	// Get the headers starting from the given :from up until the given :until
-	FetchHeadersByRange(ctx context.Context, from uint64, until uint64) ([]types.HeaderImpl, error)
-	// Get the transactions belonging to the given namespace at the block height,
-	// along with a proof that these are all such transactions.
-	FetchTransactionsInBlock(ctx context.Context, blockHeight uint64, namespace uint64) (TransactionsInBlock, error)
-	// Get the transaction by its hash.
-	FetchTransactionByHash(ctx context.Context, hash *types.TaggedBase64) (types.TransactionQueryData, error)
-	// Get the VidCommon for the given block height.
-	FetchVidCommonByHeight(ctx context.Context, blockHeight uint64) (types.VidCommon, error)
-	// Submit a transaction to the espresso sequencer.
-	SubmitTransaction(ctx context.Context, tx common.Transaction) (*common.TaggedBase64, error)
+    QueryService,
+    SubmitAPI,
 }

--- a/client/multiple_nodes_client.go
+++ b/client/multiple_nodes_client.go
@@ -16,6 +16,7 @@ import (
 
 var _ QueryService = (*MultipleNodesClient)(nil)
 var _ SubmitAPI = (*MultipleNodesClient)(nil)
+var _ EspressoClient = (*MultipleNodesClient)(nil)
 
 type MultipleNodesClient struct {
 	nodes []*Client


### PR DESCRIPTION
Closes #67 

### This PR:
Adds a public interface that encapsulates the Full API of both the client implementations. This allows consumers to use the full capabilities of the client, while still allowing for mock structures in testing.

### This PR does not:
Address any failing tests in this repo. Just-test seems to be failing, but compilation seems to be succeeding.

### Key places to review:

`client/clientApi.go`